### PR TITLE
Migrate publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,17 +17,17 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-      
+
       - name: Setup node
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-          registry-url: 'https://npm.pkg.github.com'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-      
+          registry-url: https://registry.npmjs.org/
+
       - name: Install module dependencies
         run: yarn
-      
+
       - name: Publish
-        run: yarn publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@untile:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ module.exports = {
 ```
 
 ## Rules
+
 - Commit header should start to: **Add|Bump|Fix|Improve|Release|Remove|Update**.
 - Commit header must not be longer than **52** characters.
 - Commit header must have **more than 1 word**.
@@ -26,12 +27,12 @@ module.exports = {
 - Commit body should have a full stop.
 
 **NOTE**
-Follow the [commitlint.js.org](https://commitlint.js.org/#/guides-local-setup?id=install-husky) guide 
+Follow the [commitlint.js.org](https://commitlint.js.org/#/guides-local-setup?id=install-husky) guide
 to see how to finish the configuration, using for example husky.
 
 ## Releases
 
-Be sure to have configured `GITHUB_TOKEN` in your globals.
+Be sure to have configured `NPM_TOKEN` in your globals.
 
 ```bash
 npm version [<new version> | major | minor | patch] -m "Release %s"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/untile/commitlint-config-untile.git"
+    "url": "https://github.com/untile/commitlint-config-untile.git"
   },
   "license": "MIT",
   "author": "Untile",
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@commitlint/lint": "^16.2.1",
     "@commitlint/load": "^16.2.3",
-    "@untile/eslint-config-untile": "^0.0.4",
+    "@untile/eslint-config-untile": "^0.0.5",
     "@uphold/github-changelog-generator": "^3.0.0",
     "eslint": "^7.23.0",
     "husky": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,10 +975,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@untile/eslint-config-untile@^0.0.4":
-  version "0.0.4"
-  resolved "https://npm.pkg.github.com/download/@untile/eslint-config-untile/0.0.4/6fde72450d1e70d0768fa80ce0ebec9faae338dfe2df5cf29f27b9c79ffbdc63#ca99265a28e9b3646b8f82e03e99ca4eb9e31db7"
-  integrity sha512-M549AdTmKdQfhoU0E8PuWoXVnetc0NY4uv9tsA662ewC2CxnWIg/lj1XN6Vzdgzqgx1N9cYX8FMGJlh8HS5Yig==
+"@untile/eslint-config-untile@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@untile/eslint-config-untile/-/eslint-config-untile-0.0.5.tgz#553adcbb289c27df4a5ddf1066635943e162d70e"
+  integrity sha512-PnKDRxFMYZWTiz0loRqui5r4goPurzsgXAoY02pIzyqrYX3JnuyEDDHXJaxVkk9/SnmASebbwlYkyqOQr+SNzw==
   dependencies:
     babel-eslint "10.1.0"
     eslint-plugin-jest "24.3.2"


### PR DESCRIPTION
This PR updates the `publish` workflow to be done by npm and not for github.
This also updates `@untile/eslint-config-untile` dependency.